### PR TITLE
Bump lucene-core from 5.3.2 to 7.1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
         <dependency>
             <groupId>org.apache.lucene</groupId>
             <artifactId>lucene-core</artifactId>
-            <version>5.3.2</version>
+            <version>7.1.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.lucene</groupId>


### PR DESCRIPTION
Bumps lucene-core from 5.3.2 to 7.1.0.

Signed-off-by: dependabot[bot] <support@github.com>